### PR TITLE
Make save profile button do something useful

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 Groupon Home & Auto is currently building a new platform for consumers to directly book house cleaning appointments with Groupon.
 **GWorker** is the Android app that allows fieldworkers to view their daily schedule and update price onsite.
 
-Time spent: **38** hours spent in total
+Time spent: **40** hours spent in total
 
 ## User Stories
 

--- a/app/src/main/java/com/ghomebyrw/gworker/activities/EditProfileActivity.java
+++ b/app/src/main/java/com/ghomebyrw/gworker/activities/EditProfileActivity.java
@@ -1,7 +1,9 @@
 package com.ghomebyrw.gworker.activities;
 
+import android.content.Intent;
 import android.os.Bundle;
 import android.support.v7.app.AppCompatActivity;
+import android.widget.Button;
 import android.widget.EditText;
 
 import com.ghomebyrw.gworker.R;
@@ -9,6 +11,7 @@ import com.ghomebyrw.gworker.models.FieldWorker;
 
 import butterknife.Bind;
 import butterknife.ButterKnife;
+import butterknife.OnClick;
 
 public class EditProfileActivity extends AppCompatActivity {
 
@@ -21,6 +24,7 @@ public class EditProfileActivity extends AppCompatActivity {
     @Bind(R.id.etLastName) EditText etLastName;
     @Bind(R.id.etPhoneNumber) EditText etPhoneNumber;
     @Bind(R.id.etEmail) EditText etEmail;
+    @Bind(R.id.btnSaveProfile) Button btnSaveProfile;
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {
@@ -34,10 +38,26 @@ public class EditProfileActivity extends AppCompatActivity {
         getSupportActionBar().setDisplayHomeAsUpEnabled(true);
     }
 
+    @OnClick(R.id.btnSaveProfile)
+    void saveProfile() {
+        Intent data = new Intent();
+        data.putExtra("fieldWorker", getUpdatedFieldWorker());
+        setResult(RESULT_OK, data);
+        finish();
+    }
+
     private void bindFieldWorker(FieldWorker fieldWorker) {
         etFirstName.setText(fieldWorker.getFirstName());
         etLastName.setText(fieldWorker.getLastName());
         etPhoneNumber.setText(fieldWorker.getPhoneNumber());
         etEmail.setText(fieldWorker.getEmail());
+    }
+
+    private FieldWorker getUpdatedFieldWorker() {
+        return new FieldWorker(
+                etEmail.getText().toString(),
+                etFirstName.getText().toString(),
+                etLastName.getText().toString(),
+                etPhoneNumber.getText().toString());
     }
 }

--- a/app/src/main/java/com/ghomebyrw/gworker/fragments/AccountFragment.java
+++ b/app/src/main/java/com/ghomebyrw/gworker/fragments/AccountFragment.java
@@ -1,5 +1,6 @@
 package com.ghomebyrw.gworker.fragments;
 
+import android.app.Activity;
 import android.content.Intent;
 import android.os.Bundle;
 import android.support.annotation.Nullable;
@@ -29,11 +30,13 @@ import retrofit.Retrofit;
 public class AccountFragment extends Fragment {
 
     public static final String TAG = AccountFragment.class.getName();
+    private static final int EDIT_PROFILE_REQUEST_CODE = 1;
 
     //TODO: determine id from authenticated user
     String fieldWorkerId = "fdf0399e-19cc-4d3a-b027-727fc0522050";
 
     private FieldWorker fieldWorker;
+    @Bind(R.id.accountFragmentLayout) ViewGroup layout;
     @Bind(R.id.tvFirstName) TextView tvFirstName;
     @Bind(R.id.tvLastName) TextView tvLastName;
     @Bind(R.id.tvPhoneNumber) TextView tvPhoneNumber;
@@ -72,7 +75,21 @@ public class AccountFragment extends Fragment {
     void editProfile() {
         Intent intent = new Intent(getContext(), EditProfileActivity.class);
         intent.putExtra("fieldWorker", fieldWorker);
-        startActivity(intent);
+        startActivityForResult(intent, EDIT_PROFILE_REQUEST_CODE);
+    }
+
+    @Override
+    public void onActivityResult(int requestCode, int resultCode, Intent data) {
+        if (requestCode == EDIT_PROFILE_REQUEST_CODE && resultCode == Activity.RESULT_OK) {
+            //TODO: call api to update field worker on back end
+            fieldWorker = (FieldWorker) data.getParcelableExtra("fieldWorker");
+            bindFieldWorker(fieldWorker);
+
+            // Force layout refresh. Without this, the right alignment of field values
+            // isn't properly refreshed if the new value is shorter than the old one.
+            // Is there a better way to handle this?
+            layout.invalidate();
+        }
     }
 
     private void fetchFieldWorker() {

--- a/app/src/main/res/layout/fragment_account.xml
+++ b/app/src/main/res/layout/fragment_account.xml
@@ -5,7 +5,8 @@
     android:paddingRight="@dimen/activity_horizontal_margin"
     android:paddingTop="@dimen/activity_vertical_margin"
     android:paddingBottom="@dimen/activity_vertical_margin"
-    tools:context="com.ghomebyrw.gworker.fragments.AccountFragment">
+    tools:context="com.ghomebyrw.gworker.fragments.AccountFragment"
+    android:id="@+id/accountFragmentLayout">
 
     <RatingBar
         android:id="@+id/rbRating"
@@ -100,7 +101,6 @@
         android:layout_below="@+id/separator1"
         android:layout_alignParentRight="true"
         android:layout_alignParentEnd="true"
-        android:hint="@string/last_name"
         android:textSize="16sp"/>
 
     <View


### PR DESCRIPTION
The save button on the edit profile activity now returns to the account tab and updates the displayed data. It doesn't call the field worker update api yet.
